### PR TITLE
Adds getDemandByCurriculum

### DIFF
--- a/src/demand/getDemandByCurriculum/getDemandByCurriculum.test.ts
+++ b/src/demand/getDemandByCurriculum/getDemandByCurriculum.test.ts
@@ -1,0 +1,69 @@
+import handler from './getDemandByCurriculum';
+jest.mock('../../global/postgres')
+
+import client from '../../global/postgres'
+import { APIGatewayProxyEvent } from 'aws-lambda';
+const testDate = new Date('8/6/2021').toISOString().substring(0, 10);
+
+const inputWithoutDates: unknown = { pathParameters: { curriculumId: 1 } }
+const inputWithDates: unknown = { pathParameters: {
+    curriculumId: 1,
+    startDate: testDate,
+    endDate: testDate,
+} }
+const inputWithStartDate: unknown = { pathParameters: {
+    curriculumId: 1,
+    startDate: testDate,
+} }
+const inputWithEndDate: unknown = { pathParameters: {
+    curriculumId: 1,
+    endDate: testDate,
+} }
+
+// Written by BWK
+describe('Get Demand by Curriculum Handler', () => {
+    it('should fail with 400, from an invalid path parameter', async () => {
+        const res = await handler({} as APIGatewayProxyEvent);
+        expect(res.statusCode).toEqual(400);
+    })
+
+    it('should succeed with 200, from a valid dateless input', async () => {
+        (client.query as jest.Mock).mockResolvedValueOnce({ rows: {} })
+        const res = await handler(inputWithoutDates as APIGatewayProxyEvent);
+        expect(res.statusCode).toEqual(200);
+    })
+
+    it('should succeed with 200, from a valid dated input', async () => {
+        (client.query as jest.Mock).mockResolvedValueOnce({ rows: {} })
+        const res = await handler(inputWithDates as APIGatewayProxyEvent);
+        expect(res.statusCode).toEqual(200);
+    })
+
+    it('should fail with 500, from a database connection error', async () => {
+        (client.connect as jest.Mock).mockImplementationOnce(() => {
+            throw "error"
+        })
+        const res = await handler(inputWithDates as APIGatewayProxyEvent)
+        expect(res.statusCode).toEqual(500);
+    })
+
+    it('should fail with 400, from a database query error', async () => {
+        (client.query as jest.Mock).mockImplementationOnce(() => {
+            throw "error"
+        })
+        const res = await handler(inputWithoutDates as APIGatewayProxyEvent)
+        expect(res.statusCode).toEqual(400)
+    })
+
+    it('should fail with 400, due to missing end date', async () => {
+        (client.query as jest.Mock).mockResolvedValueOnce({ rows: {} })
+        const res = await handler(inputWithStartDate as APIGatewayProxyEvent);
+        expect(res.statusCode).toEqual(400);
+    })
+
+    it('should fail with 400, due to missing start date', async () => {
+        (client.query as jest.Mock).mockResolvedValueOnce({ rows: {} })
+        const res = await handler(inputWithEndDate as APIGatewayProxyEvent);
+        expect(res.statusCode).toEqual(400);
+    })
+})

--- a/src/demand/getDemandByCurriculum/getDemandByCurriculum.ts
+++ b/src/demand/getDemandByCurriculum/getDemandByCurriculum.ts
@@ -1,0 +1,69 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { HTTPResponse } from '../../global/objects';
+import client from '../../global/postgres';
+const baseText = 'SELECT * FROM clientdemand WHERE (curriculumid = $1)';
+const optionalText = ' AND (needby BETWEEN $2 AND $3)';
+
+export interface getDemandByCurriculum {
+    curriculumId: string,
+    startDate?: string,
+    endDate?: string
+}
+
+// written by BWK
+export default async function handler(event: APIGatewayProxyEvent) {
+    // Double-checks that neither pathParameters nor curriculumId are undefined
+    //  If undefined, reject with code 400
+    if (!event.pathParameters || !event.pathParameters.curriculumId) {
+        return new HTTPResponse(400, "Invalid path parameters")
+
+    // If defined, but only a partial date range is found
+    } else if (!event.pathParameters.startDate && event.pathParameters.endDate) {
+        return new HTTPResponse(400, "Path parameter missing")
+    } else if (event.pathParameters.startDate && !event.pathParameters.endDate) {
+        return new HTTPResponse(400, "Path parameter missing")
+    }
+
+    const demand: getDemandByCurriculum = {
+        curriculumId: event.pathParameters.curriculumId,
+        startDate: event.pathParameters.startDate,
+        endDate: event.pathParameters.endDate
+    }
+
+    // Attempt to establish a connection; in the case of a failure, give
+    //  error code 500
+    try {
+        await client.connect();
+    } catch (err) {
+        console.log(err)
+        return new HTTPResponse(500, "Unable to Connect to the Database")
+    }
+
+    const demandData = [
+        demand.curriculumId,
+        demand.startDate,
+        demand.endDate
+    ];
+
+    let res, text;
+    // Appends second half of the query to the first, but only if dates are provided
+    if (demand.startDate && demand.endDate) {
+        text = baseText + optionalText;
+    } else {
+        text = baseText;
+    }
+
+    // Attempts to retrieve rows using curriculumId.
+    try {
+        res = await client.query(text, demandData)
+    } catch (err) {
+        console.log(err);
+        await client.end()
+        return new HTTPResponse(400, "Unable to Query the information")
+    }
+
+    // If all went well, returns everything that the query retrieved
+    await client.end()
+    console.log(res.rows);
+    return new HTTPResponse(200, res.rows)
+};


### PR DESCRIPTION
## Description
Implements getDemandByCurriculum function and unit tests for it; takes in curriculum id and, optionally, a start and end date, and returns rows from the clientdemand table

## Motivation and Context
Continues to solve [issue 25](https://github.com/Perfect-Personnel-Placement/backend/issues/25) by adding functionality to retrieve from the Client-Demand table.

## How has this been tested?
Unit tests run successfully after implementation

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] All new and existing tests passed.